### PR TITLE
rtp_engine: add support for multirate 2833 DRAFT

### DIFF
--- a/include/asterisk/rtp_engine.h
+++ b/include/asterisk/rtp_engine.h
@@ -311,6 +311,8 @@ struct ast_rtp_payload_type {
 	unsigned int primary_mapping:1;
 	/*! When the payload type became non-primary. */
 	struct timeval when_retired;
+	/*! Sample rate to over-ride mime type defaults */
+	unsigned int sample_rate;
 };
 
 /* Common RTCP report types */
@@ -757,10 +759,12 @@ struct ast_rtp_codecs {
 	AST_VECTOR(, struct ast_rtp_payload_type *) payload_mapping_tx;
 	/*! The framing for this media session */
 	unsigned int framing;
+	/*! The preferred format, as the mappings are numerically sorted */
+	struct ast_format *preferred_format;
 };
 
 #define AST_RTP_CODECS_NULL_INIT \
-    { .codecs_lock = AST_RWLOCK_INIT_VALUE, .payload_mapping_rx = { 0, }, .payload_mapping_tx = { 0, }, .framing = 0, }
+    { .codecs_lock = AST_RWLOCK_INIT_VALUE, .payload_mapping_rx = { 0, }, .payload_mapping_tx = { 0, }, .framing = 0, .preferred_format = NULL }
 
 /*! Structure that represents the glue that binds an RTP instance to a channel */
 struct ast_rtp_glue {
@@ -1660,6 +1664,50 @@ enum ast_media_type ast_rtp_codecs_get_stream_type(struct ast_rtp_codecs *codecs
 struct ast_rtp_payload_type *ast_rtp_codecs_get_payload(struct ast_rtp_codecs *codecs, int payload);
 
 /*!
+ * \brief Retrieve rx preferred format
+ *
+ * \param codecs Codecs structure to look in
+ *
+ * \return format information.
+ * \retval NULL if format does not exist.
+ *
+ * \note The format returned by this function has its reference count increased.
+ *       Callers are responsible for decrementing the reference count.
+ *
+ * Example usage:
+ *
+ * \code
+ * struct ast_format *payload_format;
+ * payload_format = ast_rtp_codecs_get_preferred_format(&codecs);
+ * \endcode
+ *
+ * This looks up the preferred format on the codec
+ */
+struct ast_format *ast_rtp_codecs_get_preferred_format(struct ast_rtp_codecs *codecs);
+
+/*!
+ * \brief Set the preferred format
+ *
+ * \param codecs Codecs structure to set the preferred format in
+ * \param format Preferred format to set.
+ *
+ * \return 0
+ *
+ * \note The format passed this function has its reference count increased. If an existing
+ * 		 format is set, that format is replaced.
+ *
+ * Example usage:
+ *
+ * \code
+ * struct ast_format *preferred_format = ast_format_cap_get_format(joint, 0);
+ * ast_rtp_codecs_set_preferred_format(&codecs, preferred_format));
+ * \endcode
+ *
+ * This sets the first joint format as the preferred format.
+ */
+int ast_rtp_codecs_set_preferred_format(struct ast_rtp_codecs *codecs, struct ast_format *format);
+
+/*!
  * \brief Update the format associated with a tx payload type in a codecs structure
  *
  * \param codecs Codecs structure to operate on
@@ -1774,6 +1822,36 @@ void ast_rtp_codecs_payload_formats(struct ast_rtp_codecs *codecs, struct ast_fo
  */
 int ast_rtp_codecs_payload_code(struct ast_rtp_codecs *codecs, int asterisk_format, struct ast_format *format, int code);
 
+
+/*!
+ * \brief Retrieve a rx mapped payload type based on whether it is an Asterisk format, the code and the sample rate.
+ *
+ * \param codecs Codecs structure to look in
+ * \param asterisk_format Non-zero if the given Asterisk format is present
+ * \param format Asterisk format to look for
+ * \param code The format to look for
+ * \param sample_rate Non-zero if we want to also match on sample rate.
+ *
+ * \details
+ * Find the currently assigned rx mapped payload type based on whether it
+ * is an Asterisk format or non-format code.  If one is currently not
+ * assigned then create a rx payload type mapping.
+ *
+ * \return Numerical payload type
+ * \retval -1 if could not assign.
+ *
+ * Example usage:
+ *
+ * \code
+ * int payload = ast_rtp_codecs_payload_code_sample_rate(&codecs, 0, NULL, AST_RTP_DTMF, 8000);
+ * \endcode
+ *
+ * This looks for the numerical payload for a DTMF type with a sample rate of 8kHz in the codecs structure.
+ *
+ * \since 21.0.0
+ */
+int ast_rtp_codecs_payload_code_sample_rate(struct ast_rtp_codecs *codecs, int asterisk_format, struct ast_format *format, int code, unsigned int sample_rate);
+
 /*!
  * \brief Set a payload code for use with a specific Asterisk format
  *
@@ -1789,6 +1867,21 @@ int ast_rtp_codecs_payload_code(struct ast_rtp_codecs *codecs, int asterisk_form
 int ast_rtp_codecs_payload_set_rx(struct ast_rtp_codecs *codecs, int code, struct ast_format *format);
 
 /*!
+ * \brief Set a payload code with sample rate for use with a specific Asterisk format
+ *
+ * \param codecs Codecs structure to manipulate
+ * \param code The payload code
+ * \param format Asterisk format
+ * \param sample_rate Sample rate of the format, 0 to use the format's default
+ *
+ * \retval 0 Payload was set to the given format
+ * \retval -1 Payload was in use or could not be set
+ *
+ * \since 21.0.0
+ */
+int ast_rtp_codecs_payload_set_rx_sample_rate(struct ast_rtp_codecs *codecs, int code, struct ast_format *format, unsigned int sample_rate);
+
+/*!
  * \brief Retrieve a tx mapped payload type based on whether it is an Asterisk format and the code
  * \since 14.0.0
  *
@@ -1801,6 +1894,21 @@ int ast_rtp_codecs_payload_set_rx(struct ast_rtp_codecs *codecs, int code, struc
  * \retval -1 if not found.
  */
 int ast_rtp_codecs_payload_code_tx(struct ast_rtp_codecs *codecs, int asterisk_format, const struct ast_format *format, int code);
+
+/*!
+ * \brief Retrieve a tx mapped payload type based on whether it is an Asterisk format and the code
+ * \since 21.0.0
+ *
+ * \param codecs Codecs structure to look in
+ * \param asterisk_format Non-zero if the given Asterisk format is present
+ * \param format Asterisk format to look for
+ * \param code The format to look for
+ * \param sample_rate The sample rate to look for, zero if we don't care
+ *
+ * \return Numerical payload type
+ * \retval -1 if not found.
+ */
+int ast_rtp_codecs_payload_code_tx_sample_rate(struct ast_rtp_codecs *codecs, int asterisk_format, const struct ast_format *format, int code, unsigned int sample_rate);
 
 /*!
  * \brief Search for the tx payload type in the ast_rtp_codecs structure

--- a/res/res_pjsip_sdp_rtp.c
+++ b/res/res_pjsip_sdp_rtp.c
@@ -538,6 +538,9 @@ static int set_caps(struct ast_sip_session *session,
 			ast_codec_media_type2str(session_media->type),
 			ast_format_cap_get_names(caps, &usbuf),
 			ast_format_cap_get_names(peer, &thembuf));
+	} else {
+		struct ast_format *preferred_format = ast_format_cap_get_format(joint, 0);
+		ast_rtp_codecs_set_preferred_format(&codecs, preferred_format);
 	}
 
 	if (is_offer) {
@@ -559,7 +562,7 @@ static int set_caps(struct ast_sip_session *session,
 			AST_MEDIA_TYPE_UNKNOWN);
 		ast_format_cap_remove_by_type(caps, media_type);
 
-		if (session->endpoint->preferred_codec_only){
+		if (session->endpoint->preferred_codec_only) {
 			struct ast_format *preferred_fmt = ast_format_cap_get_format(joint, 0);
 			ast_format_cap_append(caps, preferred_fmt, 0);
 			ao2_ref(preferred_fmt, -1);
@@ -638,6 +641,42 @@ static pjmedia_sdp_attr* generate_rtpmap_attr(struct ast_sip_session *session, p
 
 	rtpmap.pt = media->desc.fmt[media->desc.fmt_count - 1];
 	rtpmap.clock_rate = ast_rtp_lookup_sample_rate2(asterisk_format, format, code);
+	pj_strdup2(pool, &rtpmap.enc_name, ast_rtp_lookup_mime_subtype2(asterisk_format, format, code, options));
+	if (!pj_stricmp2(&rtpmap.enc_name, "opus")) {
+		pj_cstr(&rtpmap.param, "2");
+	} else {
+		pj_cstr(&rtpmap.param, NULL);
+	}
+
+	pjmedia_sdp_rtpmap_to_attr(pool, &rtpmap, &attr);
+
+	return attr;
+}
+
+
+static pjmedia_sdp_attr* generate_rtpmap_attr2(struct ast_sip_session *session, pjmedia_sdp_media *media, pj_pool_t *pool,
+					      int rtp_code, int asterisk_format, struct ast_format *format, int code, int sample_rate)
+{
+#ifndef HAVE_PJSIP_ENDPOINT_COMPACT_FORM
+	extern pj_bool_t pjsip_use_compact_form;
+#else
+	pj_bool_t pjsip_use_compact_form = pjsip_cfg()->endpt.use_compact_form;
+#endif
+	pjmedia_sdp_rtpmap rtpmap;
+	pjmedia_sdp_attr *attr = NULL;
+	char tmp[64];
+	enum ast_rtp_options options = session->endpoint->media.g726_non_standard ?
+		AST_RTP_OPT_G726_NONSTANDARD : 0;
+
+	snprintf(tmp, sizeof(tmp), "%d", rtp_code);
+	pj_strdup2(pool, &media->desc.fmt[media->desc.fmt_count++], tmp);
+
+	if (rtp_code <= AST_RTP_PT_LAST_STATIC && pjsip_use_compact_form) {
+		return NULL;
+	}
+
+	rtpmap.pt = media->desc.fmt[media->desc.fmt_count - 1];
+	rtpmap.clock_rate = sample_rate;
 	pj_strdup2(pool, &rtpmap.enc_name, ast_rtp_lookup_mime_subtype2(asterisk_format, format, code, options));
 	if (!pj_stricmp2(&rtpmap.enc_name, "opus")) {
 		pj_cstr(&rtpmap.param, "2");
@@ -1749,6 +1788,13 @@ static int create_outgoing_sdp_stream(struct ast_sip_session *session, struct as
 	pj_sockaddr ip;
 	int direct_media_enabled = !ast_sockaddr_isnull(&session_media->direct_media_addr) &&
 		ast_format_cap_count(session->direct_media_cap);
+
+	/* Keep track of the sample rates for offered codecs so we can build matching
+	   2833 payload offers. */
+	AST_VECTOR(, int) sample_rates;
+	/* In case we can't init the sample rates, still try to do the rest. */
+	int build_dtmf_sample_rates = 1;
+
 	SCOPE_ENTER(1, "%s Type: %s %s\n", ast_sip_session_get_name(session),
 		ast_codec_media_type2str(media_type), ast_str_tmp(128, ast_stream_to_str(stream, &STR_TMP)));
 
@@ -1900,6 +1946,12 @@ static int create_outgoing_sdp_stream(struct ast_sip_session *session, struct as
 		ast_format_cap_append_from_cap(caps, ast_stream_get_formats(stream), media_type);
 	}
 
+	/* Init the sample rates before we start adding them. Assume we will have at least one. */
+	if (AST_VECTOR_INIT(&sample_rates, 1)) {
+		ast_log(LOG_ERROR, "Unable to add dtmf formats to SDP!\n");
+		build_dtmf_sample_rates = 0;
+	}
+
 	for (index = 0; index < ast_format_cap_count(caps); ++index) {
 		struct ast_format *format = ast_format_cap_get_format(caps, index);
 
@@ -1938,7 +1990,24 @@ static int create_outgoing_sdp_stream(struct ast_sip_session *session, struct as
 		}
 
 		if ((attr = generate_rtpmap_attr(session, media, pool, rtp_code, 1, format, 0))) {
+			int newrate = ast_rtp_lookup_sample_rate2(1, format, 0);
+			int i, added = 0;
 			media->attr[media->attr_count++] = attr;
+
+			if (build_dtmf_sample_rates) {
+				for (i = 0; i < AST_VECTOR_SIZE(&sample_rates); i++) {
+					/* Only add if we haven't already processed this sample rate. For instance
+						A-law and u-law 'share' one 8K DTMF payload type. */
+					if (newrate == AST_VECTOR_GET(&sample_rates, i)) {
+						added = 1;
+						break;
+					}
+				}
+
+				if (!added) {
+					AST_VECTOR_APPEND(&sample_rates, newrate);
+				}
+			}
 		}
 
 		if ((attr = generate_fmtp_attr(pool, format, rtp_code))) {
@@ -1963,20 +2032,38 @@ static int create_outgoing_sdp_stream(struct ast_sip_session *session, struct as
 			if (!(noncodec & index)) {
 				continue;
 			}
-			rtp_code = ast_rtp_codecs_payload_code(
-				ast_rtp_instance_get_codecs(session_media->rtp), 0, NULL, index);
-			if (rtp_code == -1) {
-				continue;
-			}
 
-			if ((attr = generate_rtpmap_attr(session, media, pool, rtp_code, 0, NULL, index))) {
-				media->attr[media->attr_count++] = attr;
-			}
 
-			if (index == AST_RTP_DTMF) {
-				snprintf(tmp, sizeof(tmp), "%d 0-16", rtp_code);
-				attr = pjmedia_sdp_attr_create(pool, "fmtp", pj_cstr(&stmp, tmp));
-				media->attr[media->attr_count++] = attr;
+			if (index != AST_RTP_DTMF) {
+				rtp_code = ast_rtp_codecs_payload_code(
+								ast_rtp_instance_get_codecs(session_media->rtp), 0, NULL, index);
+				if (rtp_code == -1) {
+					continue;
+				} else if ((attr = generate_rtpmap_attr(session, media, pool, rtp_code, 0, NULL, index))) {
+					media->attr[media->attr_count++] = attr;
+				}
+			} else if (build_dtmf_sample_rates) {
+				/*
+				 * Walk through the possible bitrates for the 2833/4733 digits and generate the rtpmap
+				 * attributes.
+				 */
+				int i;
+				for (i = 0; i < AST_VECTOR_SIZE(&sample_rates); i++) {
+					rtp_code = ast_rtp_codecs_payload_code_sample_rate(
+									ast_rtp_instance_get_codecs(session_media->rtp), 0, NULL, index, AST_VECTOR_GET(&sample_rates, i));
+
+					if (rtp_code == -1) {
+						continue;
+					}
+
+					if ((attr = generate_rtpmap_attr2(session, media, pool, rtp_code, 0, NULL, index, AST_VECTOR_GET(&sample_rates, i)))) {
+						media->attr[media->attr_count++] = attr;
+						snprintf(tmp, sizeof(tmp), "%d 0-16", (rtp_code));
+						attr = pjmedia_sdp_attr_create(pool, "fmtp", pj_cstr(&stmp, tmp));
+						media->attr[media->attr_count++] = attr;
+
+					}
+				}
 			}
 
 			if (media->desc.fmt_count == PJMEDIA_MAX_SDP_FMT) {
@@ -1985,6 +2072,8 @@ static int create_outgoing_sdp_stream(struct ast_sip_session *session, struct as
 		}
 	}
 
+	/* we are done with the sample rates */
+	AST_VECTOR_FREE(&sample_rates);
 
 	/* If no formats were actually added to the media stream don't add it to the SDP */
 	if (!media->desc.fmt_count) {

--- a/res/res_rtp_asterisk.c
+++ b/res/res_rtp_asterisk.c
@@ -434,6 +434,7 @@ struct ast_rtp {
 	unsigned int dtmf_timeout;        /*!< When this timestamp is reached we consider END frame lost and forcibly abort digit */
 	unsigned int dtmfsamples;
 	enum ast_rtp_dtmf_mode dtmfmode;  /*!< The current DTMF mode of the RTP stream */
+	unsigned int dtmfsampleratems;
 	/* DTMF Transmission Variables */
 	unsigned int lastdigitts;
 	char sending_digit;	/*!< boolean - are we sending digits */
@@ -4284,8 +4285,10 @@ static int ast_rtp_dtmf_begin(struct ast_rtp_instance *instance, char digit)
 	struct ast_rtp *rtp = ast_rtp_instance_get_data(instance);
 	struct ast_sockaddr remote_address = { {0,} };
 	int hdrlen = 12, res = 0, i = 0, payload = 101;
+	unsigned int sample_rate = 8000;
 	char data[256];
 	unsigned int *rtpheader = (unsigned int*)data;
+	RAII_VAR(struct ast_format *, payload_format, NULL, ao2_cleanup);
 
 	ast_rtp_instance_get_remote_address(instance, &remote_address);
 
@@ -4310,12 +4313,32 @@ static int ast_rtp_dtmf_begin(struct ast_rtp_instance *instance, char digit)
 		return -1;
 	}
 
-	/* Grab the payload that they expect the RFC2833 packet to be received in */
-	payload = ast_rtp_codecs_payload_code_tx(ast_rtp_instance_get_codecs(instance), 0, NULL, AST_RTP_DTMF);
+	if (rtp->lasttxformat == ast_format_none) {
+		/* No audio frames have been written yet so we have to lookup both the preferred payload type and bitrate. */
+		payload_format = ast_rtp_codecs_get_preferred_format(ast_rtp_instance_get_codecs(instance));
+		if (payload_format) {
+			/* If we have a preferred type, use that. Otherwise default to 8K. */
+			sample_rate = ast_format_get_sample_rate(payload_format);
+		}
+	} else {
+		sample_rate = ast_format_get_sample_rate(rtp->lasttxformat);
+	}
+
+	/* Grab the matching DTMF type payload */
+	payload = ast_rtp_codecs_payload_code_tx_sample_rate(ast_rtp_instance_get_codecs(instance), 0, NULL, AST_RTP_DTMF, sample_rate);
+
+	/* If this returns -1, we are being asked to send digits for a sample rate that is outside
+	   what was negotiated for. Fall back if possible. */
+	if (payload == -1) {
+		return -1;
+	}
+	ast_test_suite_event_notify("DTMF_BEGIN","Digit: %d\r\nPayload: %d\r\nRate: %d\r\n", digit, payload, sample_rate);
+	ast_debug(1, "Sending digit '%d' at rate %d with payload %d\n", digit, sample_rate, payload);
 
 	rtp->dtmfmute = ast_tvadd(ast_tvnow(), ast_tv(0, 500000));
 	rtp->send_duration = 160;
-	rtp->lastts += calc_txstamp(rtp, NULL) * DTMF_SAMPLE_RATE_MS;
+	rtp->dtmfsampleratems = (sample_rate / 1000);
+	rtp->lastts += calc_txstamp(rtp, NULL) * rtp->dtmfsampleratems;
 	rtp->lastdigitts = rtp->lastts + rtp->send_duration;
 
 	/* Create the actual packet that we will be sending */
@@ -4394,7 +4417,7 @@ static int ast_rtp_dtmf_continuation(struct ast_rtp_instance *instance)
 	/* And now we increment some values for the next time we swing by */
 	rtp->seqno++;
 	rtp->send_duration += 160;
-	rtp->lastts += calc_txstamp(rtp, NULL) * DTMF_SAMPLE_RATE_MS;
+	rtp->lastts += calc_txstamp(rtp, NULL) * rtp->dtmfsampleratems;
 
 	return 0;
 }
@@ -4472,7 +4495,7 @@ static int ast_rtp_dtmf_end_with_duration(struct ast_rtp_instance *instance, cha
 	res = 0;
 
 	/* Oh and we can't forget to turn off the stuff that says we are sending DTMF */
-	rtp->lastts += calc_txstamp(rtp, NULL) * DTMF_SAMPLE_RATE_MS;
+	rtp->lastts += calc_txstamp(rtp, NULL) * rtp->dtmfsampleratems;
 
 	/* Reset the smoother as the delivery time stored in it is now out of date */
 	if (rtp->smoother) {


### PR DESCRIPTION
DRAFT PR - demonstrate a method for handling non 8K 2833 digit sdp offers.

Changes to the engine itself limited to adding the 48/24K types.

res_pjsip_sdp_rtp is changed to note the number of incoming codecs and add an associated offer